### PR TITLE
add table style

### DIFF
--- a/lib/done.js
+++ b/lib/done.js
@@ -301,6 +301,11 @@ var mdParse = function (data) {
         return ' <a href="#' + id + '" class="footnote-backref" target="_self">↩</a>';
     };
 
+    // add table style 
+    md.renderer.rules.table_open = function (tokens, idx) {
+        return '<table class="ui celled table">\n'
+    }
+
     // autospacing in remarkable
     if (config['custom'].autospacing) {
         md.renderer.rules.text = function (tokens, idx) {


### PR DESCRIPTION
The \<table\>\<\/table\> does not have a suitable style, so I add some class for the table.

**Previous screenshot**
![before](https://user-images.githubusercontent.com/25103697/41426917-cd49ea8a-7037-11e8-891a-121ffcd3e10c.png)

**Modified screenshot**
![after](https://user-images.githubusercontent.com/25103697/41426956-ebb027c8-7037-11e8-8821-005638116b34.png)
